### PR TITLE
move pgpy dependency to testing instead of as a core dependency for now

### DIFF
--- a/core/README.rst
+++ b/core/README.rst
@@ -22,7 +22,8 @@ To use the code and run tests you need to have installed:
 - something to speed up gpg key creation, e.g.
   by installing "rng-tools" on debian.
 
-- python2.7 and python3.5 if you can.
+- python2.7 and python3.5 including headers
+  ("python2.7-dev" and "python3.5-dev" on debian).
   If python3.5 is not present tests for it
   will be skipped.
 

--- a/core/setup.py
+++ b/core/setup.py
@@ -30,7 +30,7 @@ def main():
             [console_scripts]
             autocrypt=autocrypt.cmdline:autocrypt_main
         ''',
-        install_requires = ["click>=6.0", "six", "PGPy>=0.4.1"],
+        install_requires = ["click>=6.0", "six"],
         zip_safe=False,
     )
 

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -11,7 +11,6 @@ from _pytest.pytester import LineMatcher
 from autocrypt.bingpg import find_executable, BinGPG
 from autocrypt import mime
 from autocrypt.account import Account
-from autocrypt.pgpycrypto import PGPyCrypto
 
 
 def pytest_addoption(parser):
@@ -100,6 +99,7 @@ def crypto_maker(request, tmpdir):
     counter = itertools.count()
 
     def maker(native=False):
+        from autocrypt.pgpycrypto import PGPyCrypto
         if native:
             pgpycrypto = PGPyCrypto()
         else:

--- a/core/tox.ini
+++ b/core/tox.ini
@@ -5,8 +5,9 @@ skip_missing_interpreters = True
 [testenv]
 deps = 
     pytest
-    pytest-catchlog
-    pytest-localserver
+    py27,py35: pytest-catchlog
+    py27,py35: pytest-localserver
+    py27,py35: pgpy>=0.4.1
 
 commands = 
     pytest {posargs:--no-test-cache --with-gpg2}

--- a/core/tox.ini
+++ b/core/tox.ini
@@ -5,9 +5,9 @@ skip_missing_interpreters = True
 [testenv]
 deps = 
     pytest
-    py27,py35: pytest-catchlog
-    py27,py35: pytest-localserver
-    py27,py35: pgpy>=0.4.1
+    pytest-catchlog
+    pytest-localserver
+    pgpy>=0.4.1
 
 commands = 
     pytest {posargs:--no-test-cache --with-gpg2}
@@ -15,6 +15,7 @@ commands =
 [testenv:doc]
 deps =
     sphinx
+    pgpy>=0.4.1
 whitelist_externals = make
 changedir = ../doc
 commands =


### PR DESCRIPTION
Requiring "pgpy" for a plain "pip install autocrypt" requires python-headers on linux and might prevent some users from installing it which makes no sense as long as the code is not in the main path. 